### PR TITLE
Add ESP8266 to library.properties architectures

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Extended Database Library
 paragraph=This Arduino Extended Database Library increases the maximum number of records allowed in a database from 256 records (byte) to a theoretical maximum of 4,294,967,295 records (unsigned long). The maximum record size was also increased from 256 bytes (byte) to 65,534 bytes (unsigned int).  You may use this library in conjunction with the standard Arduino EEPROM library, an external EEPROM such as the AT24C1024, or any other platform that supports byte level reading and writing such as an SD card.
 category=Data Storage
 url=https://github.com/jwhiddon/EDB
-architectures=avr
+architectures=avr,esp8266


### PR DESCRIPTION
Eliminate the following warning for Adafruit Feather HUZZAH ESP8266:

```
WARNING: library EDB claims to run on [avr] architecture(s) and may be incompatible with your current board which runs on [esp8266] architecture(s).
```
